### PR TITLE
refactor: update linux default dirs with 26R1 default locations

### DIFF
--- a/doc/source/changelog/300.miscellaneous.md
+++ b/doc/source/changelog/300.miscellaneous.md
@@ -1,0 +1,1 @@
+Refactor: update linux default dirs with 26R1 default locations

--- a/src/ansys/tools/common/path/path.py
+++ b/src/ansys/tools/common/path/path.py
@@ -42,7 +42,7 @@ LOG = logging.getLogger(__name__)
 PRODUCT_TYPE = Literal["mapdl", "mechanical", "dyna"]
 SUPPORTED_VERSIONS_TYPE = Dict[int, str]
 
-linux_default_dirs = [["/", "usr", "ansys_inc"], ["/", "ansys_inc"], ["/", "install", "ansys_inc"]]
+linux_default_dirs = [["/", "usr", "ansys_inc"], ["/", "ansys_inc"], ["/", "install", "ansys_inc"], ["/", "opt", "ansys_inc"]]
 LINUX_DEFAULT_DIRS = [str(Path(*each)) for each in linux_default_dirs]
 
 CONFIG_FILE_NAME = "config.txt"

--- a/src/ansys/tools/common/path/path.py
+++ b/src/ansys/tools/common/path/path.py
@@ -42,7 +42,13 @@ LOG = logging.getLogger(__name__)
 PRODUCT_TYPE = Literal["mapdl", "mechanical", "dyna"]
 SUPPORTED_VERSIONS_TYPE = Dict[int, str]
 
-linux_default_dirs = [["/", "usr", "ansys_inc"], ["/", "ansys_inc"], ["/", "install", "ansys_inc"], ["/", "opt", "ansys_inc"]]
+linux_default_dirs = [
+    ["/", "usr", "ansys_inc"],
+    ["/", "ansys_inc"],
+    ["/", "install", "ansys_inc"],
+    ["/", "opt", "ansys_inc"],
+    str(Path.home() / "ansys_inc"),
+]
 LINUX_DEFAULT_DIRS = [str(Path(*each)) for each in linux_default_dirs]
 
 CONFIG_FILE_NAME = "config.txt"


### PR DESCRIPTION
When installing Rocky 26R1 I ended up installing in my HOME folder as a user and in "/opt" when running as root.
Extending the list with those location will allow to work with "recent" default locations :) 